### PR TITLE
Fix typo in connecting Github

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -44,7 +44,7 @@ connectButtonElement.addEventListener("click", async (event) => {
   const repo = repoElement.value;
   const filename = filenameElement.value;
 
-  connectButtonElement.innerText = "🔗 Connection…";
+  connectButtonElement.innerText = "🔗 Connecting…";
 
   try {
     const markdownString = await getContentString({ accessToken, username, repo, filename });


### PR DESCRIPTION
When making connection to Github, the button shows "Connection...". This pr changes that to "Connecting...".